### PR TITLE
add SESSION_REDIS_JSON_ENCODING setting

### DIFF
--- a/redis_sessions_fork/serializers.py
+++ b/redis_sessions_fork/serializers.py
@@ -1,12 +1,14 @@
+from .settings import SESSION_REDIS_JSON_ENCODING
+
 try:
     import ujson
 
     class UjsonSerializer(object):
         def dumps(self, obj):
-            return ujson.dumps(obj).encode('latin-1')
+            return ujson.dumps(obj).encode(SESSION_REDIS_JSON_ENCODING)
 
         def loads(self, data):
-            return ujson.loads(data.decode('latin-1'))
+            return ujson.loads(data.decode(SESSION_REDIS_JSON_ENCODING))
 except ImportError:
     pass
 

--- a/redis_sessions_fork/settings.py
+++ b/redis_sessions_fork/settings.py
@@ -47,6 +47,12 @@ SESSION_REDIS_CONNECTION_POOL = getattr(
     None
 )
 
+SESSION_REDIS_JSON_ENCODING = getattr(
+    settings,
+    'SESSION_REDIS_JSON_ENCODING',
+    'latin-1'
+)
+
 if SESSION_REDIS_URL is None:
     # redis clouds ENV variables
     SESSION_REDIS_ENV_URLS = getattr(


### PR DESCRIPTION
a setting that let users configure which encoding is used for the JSON serializer
