### PR TITLE
Only search for the key prefix at the beginning of the key.

### DIFF
--- a/redis_sessions_fork/utils.py
+++ b/redis_sessions_fork/utils.py
@@ -17,7 +17,7 @@ from . import settings
 
 def add_prefix(key):
     if settings.SESSION_REDIS_PREFIX:
-        if not settings.SESSION_REDIS_PREFIX in str(key):
+        if not str(key).startswith('%s:' % settings.SESSION_REDIS_PREFIX):
             return '%s:%s' % (
                 settings.SESSION_REDIS_PREFIX,
                 key


### PR DESCRIPTION
Consider a prefix of "demo" and key of "demo".
The raw prefix is in the key already, while there isn't much to do, we also only care to search the front of the key.
