### PR TITLE
Add support for Django 1.8

### DIFF
--- a/redis_sessions_fork/management/commands/flush_orm_sessions.py
+++ b/redis_sessions_fork/management/commands/flush_orm_sessions.py
@@ -14,11 +14,13 @@ class Command(NoArgsCommand):
             cursor.execute(
                 'TRUNCATE TABLE %s' % Session._meta.db_table
             )
-            transaction.commit_unless_managed()
+            if hasattr(transaction, 'commit_unless_managed'):
+                transaction.commit_unless_managed()
         except DatabaseError:  # sqlite fix
             cursor.execute(
                 'DELETE FROM %s' % Session._meta.db_table
             )
-            transaction.commit_unless_managed()
+            if hasattr(transaction, 'commit_unless_managed'):
+                transaction.commit_unless_managed()
         except DatabaseError:  # otherwise via django orm
             Session.objects.all.delete()

--- a/redis_sessions_fork/session.py
+++ b/redis_sessions_fork/session.py
@@ -22,11 +22,11 @@ class SessionStore(SessionBase):
         if session_data is not None:
             return self.decode(session_data)
         else:
-            self.create()
+            self._session_key = None
             return {}
 
     def exists(self, session_key):
-        return backend.exists(session_key)
+        return session_key and backend.exists(session_key)
 
     def create(self):
         while True:

--- a/tox.ini
+++ b/tox.ini
@@ -8,20 +8,25 @@ envlist =
     py27-dj15,
     py27-dj16,
     py27-dj17,
+    py27-dj18,
     py32-dj15,
     py32-dj15,
     py32-dj17,
+    py32-dj18,
     py33-dj15,
     py33-dj16,
     py33-dj17,
+    py33-dj18,
     py34-dj15,
     py34-dj16,
     py34-dj17,
+    py34-dj18,
     pypy-dj13,
     pypy-dj14,
     pypy-dj15,
     pypy-dj16,
-    pypy-dj17
+    pypy-dj17,
+    pypy-dj18
 
 [base-pypy]
 deps =
@@ -83,7 +88,13 @@ deps =
 [testenv:py27-dj17]
 basepython=python2.7
 deps =
-    https://github.com/django/django/tarball/stable/1.7.x#egg=django
+    Django>=1.7,<1.8
+    {[base]deps}
+
+[testenv:py27-dj18]
+basepython=python2.7
+deps =
+    Django>=1.8,<1.9
     {[base]deps}
 
 [testenv:py32-dj15]
@@ -101,7 +112,13 @@ deps =
 [testenv:py32-dj17]
 basepython=python3.2
 deps =
-    https://github.com/django/django/tarball/stable/1.7.x#egg=django
+    Django>=1.7,<1.8
+    {[base]deps}
+
+[testenv:py32-dj18]
+basepython=python3.2
+deps =
+    Django>=1.8,<1.9
     {[base]deps}
 
 [testenv:py33-dj15]
@@ -119,7 +136,13 @@ deps =
 [testenv:py33-dj17]
 basepython=python3.3
 deps =
-    https://github.com/django/django/tarball/stable/1.7.x#egg=django
+    Django>=1.7,<1.8
+    {[base]deps}
+
+[testenv:py33-dj18]
+basepython=python3.3
+deps =
+    Django>=1.8,<1.9
     {[base]deps}
 
 [testenv:py34-dj15]
@@ -137,7 +160,13 @@ deps =
 [testenv:py34-dj17]
 basepython=python3.4
 deps =
-    https://github.com/django/django/tarball/stable/1.7.x#egg=django
+    Django>=1.7,<1.8
+    {[base]deps}
+
+[testenv:py34-dj18]
+basepython=python3.4
+deps =
+    Django>=1.8,<1.9
     {[base]deps}
 
 [testenv:pypy-dj13]
@@ -167,6 +196,12 @@ deps =
 [testenv:pypy-dj17]
 basepython=pypy
 deps =
-    https://github.com/django/django/tarball/stable/1.7.x#egg=django
+    Django>=1.7,<1.8
+    {[base-pypy]deps}
+
+[testenv:pypy-dj18]
+basepython=pypy
+deps =
+    Django>=1.8,<1.9
     {[base-pypy]deps}
 


### PR DESCRIPTION
* Fixed the flush_orm_sessions command to work under Django 1.8
* Added tox environments for Django 1.8 with all supported Python versions
* Implemented a fix for the denial-of-service risk outlined in https://www.djangoproject.com/weblog/2015/jul/08/security-releases/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hellysmile/django-redis-sessions-fork/10)
<!-- Reviewable:end -->
