### PR TITLE
Changed import_module import source 

### DIFF
--- a/redis_sessions_fork/utils.py
+++ b/redis_sessions_fork/utils.py
@@ -10,7 +10,7 @@ try:  # Django >= 1.4
 except ImportError:  # Django < 1.4
     from datetime import datetime
     timezone = datetime
-from django.utils.importlib import import_module
+from importlib import import_module
 
 from .conf import settings
 


### PR DESCRIPTION
…to eliminate deprecation warning in Django 1.8.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hellysmile/django-redis-sessions-fork/11)

<!-- Reviewable:end -->
